### PR TITLE
Rework workflows + secrets

### DIFF
--- a/.github/workflows/checkBuild.yml
+++ b/.github/workflows/checkBuild.yml
@@ -57,27 +57,3 @@ jobs:
       with:
         name: jars-java-${{ matrix.java }}
         path: target/*.jar
-        
-  publish-dry-run:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Set up Java
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-          cache: 'maven'
-      - name: Publish project
-        env:
-          JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.MAVEN_GPG_PUBLIC_KEY }}
-          JRELEASER_GPG_SECRET_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          JRELEASER_GITHUB_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
-          JRELEASER_NEXUS2_MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          JRELEASER_NEXUS2_MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          JRELEASER_NEXUS2_MAVEN_CENTRAL_SNAPSHOT_URL: https://s01.oss.sonatype.org/content/repositories/snapshots/
-        run: mvn -B -pl !examples -Prelease deploy org.jreleaser:jreleaser-maven-plugin:deploy -Djreleaser.dry.run -DaltDeploymentRepository=local::default::file:./target/staging-deploy

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -1,0 +1,28 @@
+name: Publish dry run
+
+on:
+  workflow_dispatch:
+
+jobs:  
+  publish-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Publish project
+        env:
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.MAVEN_GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          JRELEASER_NEXUS2_MAVEN_CENTRAL_USERNAME: ${{ secrets.S01_OSS_SONATYPE_MAVEN_USERNAME }}
+          JRELEASER_NEXUS2_MAVEN_CENTRAL_PASSWORD: ${{ secrets.S01_OSS_SONATYPE_MAVEN_TOKEN }}
+          JRELEASER_NEXUS2_MAVEN_CENTRAL_SNAPSHOT_URL: https://s01.oss.sonatype.org/content/repositories/snapshots/
+        run: mvn -B -pl !examples -Prelease deploy org.jreleaser:jreleaser-maven-plugin:deploy -Djreleaser.dry.run -DaltDeploymentRepository=local::default::file:./target/staging-deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,9 +97,8 @@ jobs:
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.MAVEN_GPG_PUBLIC_KEY }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          JRELEASER_GITHUB_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
-          JRELEASER_NEXUS2_MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          JRELEASER_NEXUS2_MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          JRELEASER_NEXUS2_MAVEN_CENTRAL_USERNAME: ${{ secrets.S01_OSS_SONATYPE_MAVEN_USERNAME }}
+          JRELEASER_NEXUS2_MAVEN_CENTRAL_PASSWORD: ${{ secrets.S01_OSS_SONATYPE_MAVEN_TOKEN }}
         run: mvn -B -pl !examples -Prelease deploy org.jreleaser:jreleaser-maven-plugin:deploy -DaltDeploymentRepository=local::default::file:./target/staging-deploy
   after_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As we are currently [relocating from ``com.xdev-software`` to ``software.xdev``](https://github.com/xdev-software/github/issues/5) we also changed the secrets due to security reasons.

| Old secret | New secret |
| --- | --- |
| MAVEN_CENTRAL_TOKEN | S01_OSS_SONATYPE_MAVEN_TOKEN |
| MAVEN_CENTRAL_USERNAME | S01_OSS_SONATYPE_MAVEN_USERNAME |

The old secrets will no longer work as we will revoke/reset them.

This PR changes this, however the JReleases config looks broken:
https://github.com/xdev-software/micro-migration/blob/e8487f0ce8e3e619a828e46c8278c3ffbcf16ed1/.github/workflows/release.yml#L100-L102

* JRELEASER_GITHUB_TOKEN is set to MAVEN_CENTRAL_TOKEN?
* MAVEN_CENTRAL_PASSWORD is not tracked in our organization secrets

---

I also noticed that on each PR/commit a ``publish-dry-run`` is executed...
https://github.com/xdev-software/micro-migration/blob/e8487f0ce8e3e619a828e46c8278c3ffbcf16ed1/.github/workflows/checkBuild.yml#L61-L83

I moved this into a separate workflow, that can be triggered manually as this is not required to check the build (may not work on forked repo-PRs due to missing secrets) and may cause a poorly noticeable security leak.

---

After merging please cleanup/remove the following ["Repository secrets"](https://github.com/xdev-software/micro-migration/settings/secrets/actions):
* GRADLE_TOKEN -> unused
* MAVEN_CENTRAL_PASSWORD -> should no longer be needed